### PR TITLE
update `tracing-subscriber` to 0.2.0 stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ futures-util = { version = "0.3.1", features = ["sink"] }
 tokio = { version = "0.2.6", features = ["tcp", "io-util", "dns", "rt-core", "rt-threaded", "time", "udp"] }
 tokio-util = { version = "0.2.0", features = ["codec", "udp"] }
 tracing-core = "0.1.8"
-tracing-subscriber = "0.2.0-alpha.2"
+tracing-subscriber = "0.2.0"
 
 [dev-dependencies]
 tokio = { version = "0.2.6", features = ["macros"] }


### PR DESCRIPTION
`tracing-subscriber` 0.2.0-stable is a major release with several bug
fixes, including fixes for a memory leak in the `Registry` span storage.
Since Cargo cannot automatically update versions ending with `-alpha.X`,
crates depending on earlier `tracing-subscriber` 0.2.0 alpha releases
should update to stable. 

See tokio-rs/tracing#567 for the complete changelog.