### PR TITLE
Upgrade to tracing-subscriber 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tokio-rustls = { version = "0.23", optional = true }
 tokio-util = { version = "0.6", features = ["codec", "net"] }
 tracing-core = "0.1"
 tracing-futures = "0.2"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }


### PR DESCRIPTION
Updated the library to use the newer tracing-subscriber traits.
Changed the least amount of code possible and tested checking for regression.
Bumped the library version as the interfaces have changed.