### PR TITLE
Rename message field to short_message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! * [`Event`] fields are inserted as [`GELF`] additional fields, `_field_name`.
 //! * [`Event`] field named `message` is renamed to `short_message`.
 //! * If `short_message` (or `message`) [`Event`] field is missing then `short_message` is
-//! set to the empty string.
+//! set to a string of the format `"[LEVEL] Event"` (e.g. `"ERROR Event"`).
 //! * [`Event`] fields whose names collide with [`GELF`] required fields are coerced
 //! into the required types and overrides defaults given in the builder.
 //! * The hierarchy of spans is concatenated and inserted as `span_a:span_b:span_c` and
@@ -585,7 +585,7 @@ where
 
         if !object.contains_key("short_message") {
             let short_message = object.remove("message")
-                .unwrap_or_else(|| "".into());
+                .unwrap_or_else(|| format!("{} Event", metadata.level()).into());
             object.insert("short_message".into(), short_message);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,7 +584,9 @@ where
         event.record(&mut add_field_visitor);
 
         if !object.contains_key("short_message") {
-            object.insert("short_message".into(), "".into());
+            let short_message = object.remove("message")
+                .unwrap_or_else(|| "".into());
+            object.insert("short_message".into(), short_message);
         }
 
         // Serialize


### PR DESCRIPTION
1. Implement specification in comment that says `message` field will be renamed to `short_message`:
 https://github.com/hlb8122/tracing-gelf/blob/08ddc0b04a1fa3f5725345bdfb0504dbd95720ab/src/lib.rs#L52
2. Replace empty short_message with default string

    Graylog throws the following exception when `short_message` is the empty string:
    ```
    java.lang.IllegalArgumentException: GELF message <[UUID]> (received from <[IP addr:port]>) has empty mandatory "short_message" field.
    ```
    Instead of supplying an empty string in the absence of a `message` field, format the level and the word "Event" (e.g. `ERROR Event`).