### PR TITLE
Log errors and connection establishment to the GELF server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["io-util", "net", "time"] }
 tokio-rustls = { version = "0.23", optional = true }
 tokio-util = { version = "0.6", features = ["codec", "net"] }
+tracing = "0.1"
 tracing-core = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.3"


### PR DESCRIPTION
Previously, connecting to the wrong IP address or port would fail
silently. Now, it's at least logged (to some other logging interface,
should one be registered).

Also move the logging suppression to the inner sending loop, there
should be no harm in logging the connection establishment phase.