### PR TITLE
Update tokio-rustls to 0.24.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", features = ["sink"] }
 thiserror = "1"
 tokio = { version = "1", features = ["io-util", "net", "time"] }
-tokio-rustls = { version = "0.23", optional = true }
+tokio-rustls = { version = "0.24", optional = true }
 tracing-core = "0.1.24"
 tokio-util = { version = "0.7", features = ["codec", "net"] }
 tracing-futures = "0.2"


### PR DESCRIPTION
This transitively updates `rustls` to 0.21.

`rustls` is used by a number of crates in the Rust ecosystem, and the projects that I work on depend on it via a variety of paths. If it's possible to publish a release of `tracing-gelf` with this change, that would allow me to update a number of dependencies all together.