### PR TITLE
bump tokio_rustls to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-gelf"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Harry Barber <harrybarber@protonmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -27,8 +27,8 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", features = ["sink"] }
 thiserror = "1"
 tokio = { version = "1", features = ["io-util", "net", "time"] }
-tokio-rustls = { version = "0.23", optional = true }
-tracing-core = "0.1.24"
+tokio-rustls = { version = "0.24", optional = true }
+tracing-core = "0.1"
 tokio-util = { version = "0.7", features = ["codec", "net"] }
 tracing-futures = "0.2"
 tracing-subscriber = "0.3"


### PR DESCRIPTION
Ah, there already was an open PR for this. :shrug: 

Anyway, this change requires a "major" version bump since rustls is part of the public api.